### PR TITLE
Fix compilation error when third-party heap is not specified

### DIFF
--- a/src/hotspot/share/opto/macro.hpp
+++ b/src/hotspot/share/opto/macro.hpp
@@ -37,7 +37,9 @@ class  PhaseIterGVN;
 #endif
 
 class PhaseMacroExpand : public Phase {
+#ifdef INCLUDE_THIRD_PARTY_HEAP
     friend ThirdPartyHeapBarrierSetC2;
+#endif
 private:
   PhaseIterGVN &_igvn;
 


### PR DESCRIPTION
This PR fixes compilation error when third-party heap related flags are not specified.