### PR TITLE
enable_collection() during create_vm()

### DIFF
--- a/src/hotspot/share/gc/shared/collectedHeap.hpp
+++ b/src/hotspot/share/gc/shared/collectedHeap.hpp
@@ -201,6 +201,11 @@ class CollectedHeap : public CHeapObj<mtInternal> {
   // This is the correct place to place such initialization methods.
   virtual void post_initialize();
 
+  // Notify the heap that now collection is allowed.
+  // This is added for third party heap to avoid a third party heap starts any collection attempt
+  // before the VM is ready.
+  virtual void enable_collection() {}
+
   // Stop any onging concurrent work and prepare for exit.
   virtual void stop() {}
 

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3754,6 +3754,7 @@ jint Threads::create_vm(JavaVMInitArgs* args, bool* canTryAgain) {
   }
 
   assert(Universe::is_fully_initialized(), "not initialized");
+  Universe::heap()->enable_collection();
   if (VerifyDuringStartup) {
     // Make sure we're starting with a clean slate.
     VM_Verify verify_op;


### PR DESCRIPTION
This change is related to MMTk. 

When using a low stress_factor, MMTk may attempt GC at early times before the VM is fully initialised and is ready for GC. In such case, MMTk requires the VM to inform it when GC is enabled. This PR adds a call `enable_collection()` and invoke it during `create_vm()`. 

This is what happened in `create_vm()`. 

`create_vm()` -> `init_globals()` -> `universe_init()` -> `CollectedHeap::initialize()`
....................................................... -> `universe_post_init()` -> `CollectedHeap::post_initialize()`
................................................
.......................-> `VMThread::create()`
................................................
.......................-> `Universe::is_fully_initialized()`
.......................-> `CollectedHeap::enable_collection()` (this PR adds this. It needs to be called after `VMThread::create()`. As when a GC is triggered, for a safepoint synchronization, `VMThread` is expected to be already instantiated.)