### PR TITLE
Fix stop-the-world bug.

### DIFF
--- a/src/hotspot/share/runtime/safepoint.cpp
+++ b/src/hotspot/share/runtime/safepoint.cpp
@@ -294,7 +294,6 @@ void SafepointSynchronize::begin() {
             cur_state->examine_state_of_thread();
             if (!cur_state->is_running()) {
               still_running--;
-              Universe::heap()->report_java_thread_yield(cur);
               // consider adjusting steps downward:
               //   steps = 0
               //   steps -= NNN

--- a/src/hotspot/share/runtime/vmOperations.hpp
+++ b/src/hotspot/share/runtime/vmOperations.hpp
@@ -130,6 +130,7 @@
   template(PrintMetadata)                         \
   template(GTestExecuteAtSafepoint)               \
   template(JFROldObject)                          \
+  THIRD_PARTY_HEAP_ONLY(template(ThirdPartyHeapOperation)) \
 
 class VM_Operation: public CHeapObj<mtInternal> {
  public:


### PR DESCRIPTION
Added a VMOp_ThirdPartyHeapOperation for the third-party heap to perform
stop-the-world GC.

SafepointSynchronize::begin() no longer report "thread has stopped".