### PR TITLE
bind() in post_heap_initialize should be properly guarded by the condition.

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -341,9 +341,10 @@ void Thread::initialize_thread_current() {
 
 void Thread::post_heap_initialize() {
   #ifdef INCLUDE_THIRD_PARTY_HEAP
-    if (UseThirdPartyHeap)
+    if (UseThirdPartyHeap) {
       assert(third_party_heap::MutatorContext::is_ready_to_bind(), "Third party heap needs to be ready to bind mutator by now.");
       third_party_heap_mutator = third_party_heap::MutatorContext::bind(current());
+    }
   #endif
 }
 


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/mmtk/openjdk/pull/12. It caused MMTk to be initialized even when we are using the stock GC.