### PR TITLE
Print third-party heap version in -Xinternalversion and error report.

### DIFF
--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2710,7 +2710,7 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
                   VM_Version::internal_vm_info_string());
       #ifdef INCLUDE_THIRD_PARTY_HEAP
       jio_fprintf(defaultStream::output_stream(), "%s\n",
-                ThirdPartyHeap::version());
+                  ThirdPartyHeap::version());
       #endif
 
       vm_exit(0);

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -64,6 +64,9 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+#ifdef INCLUDE_THIRD_PARTY_HEAP
+#include THIRD_PARTY_HEAP_FILE(thirdPartyHeap.hpp)
+#endif
 
 #define DEFAULT_JAVA_LAUNCHER  "generic"
 
@@ -2705,6 +2708,11 @@ jint Arguments::parse_each_vm_init_arg(const JavaVMInitArgs* args, bool* patch_m
     } else if (match_option(option, "-Xinternalversion")) {
       jio_fprintf(defaultStream::output_stream(), "%s\n",
                   VM_Version::internal_vm_info_string());
+      #ifdef INCLUDE_THIRD_PARTY_HEAP
+      jio_fprintf(defaultStream::output_stream(), "%s\n",
+                ThirdPartyHeap::version());
+      #endif
+
       vm_exit(0);
 #ifndef PRODUCT
     // -Xprintflags

--- a/src/hotspot/share/utilities/vmError.cpp
+++ b/src/hotspot/share/utilities/vmError.cpp
@@ -55,6 +55,9 @@
 #if INCLUDE_JFR
 #include "jfr/jfr.hpp"
 #endif
+#ifdef INCLUDE_THIRD_PARTY_HEAP
+#include THIRD_PARTY_HEAP_FILE(thirdPartyHeap.hpp)
+#endif
 
 #ifndef PRODUCT
 #include <signal.h>
@@ -1028,6 +1031,9 @@ void VMError::report(outputStream* st, bool _verbose) {
 
      if (_verbose) {
        st->print_cr("vm_info: %s", Abstract_VM_Version::internal_vm_info_string());
+       #ifdef INCLUDE_THIRD_PARTY_HEAP
+       st->print_cr("heap_info: %s", ThirdPartyHeap::version());
+       #endif
        st->cr();
      }
 


### PR DESCRIPTION
This PR adds hooks to invoke `ThirdPartyHeap::version()` in `-Xinternalversion` and in VM error reports.